### PR TITLE
アセットのファイルの拡張子をProjectタブ上で見えるようにする。

### DIFF
--- a/Assets/ThirdParty.meta
+++ b/Assets/ThirdParty.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: aeec2e37315fbd64787818531d42153f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ThirdParty/ProjectPaneExtensions.meta
+++ b/Assets/ThirdParty/ProjectPaneExtensions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 987af4a69efb690498771543d5d3febd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ThirdParty/ProjectPaneExtensions/ProjectPaneExtensions.cs
+++ b/Assets/ThirdParty/ProjectPaneExtensions/ProjectPaneExtensions.cs
@@ -1,0 +1,40 @@
+// [ProjectPaneExtensions.cs](https://gist.github.com/Tenebrous/db7f6e9087d34b73de5d45c82263d131#file-projectpaneextensions-cs)
+
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+[InitializeOnLoad]
+public static class ProjectPaneExtensions
+{
+    static ProjectPaneExtensions()
+    {
+        EditorApplication.projectWindowItemOnGUI -= Draw;
+        EditorApplication.projectWindowItemOnGUI += Draw;
+    }
+
+    static GUIStyle _labelStyle;
+    static void Draw( string guid, Rect selectionrect )
+    {
+        var path = AssetDatabase.GUIDToAssetPath( guid );
+
+        // skip invalid names
+        if( string.IsNullOrWhiteSpace( path ) )
+            return;
+
+        // don't touch the two-column layout
+        if( selectionrect.height > 20 )
+            return;
+
+        if( _labelStyle == null )
+            _labelStyle = new GUIStyle( EditorStyles.label );
+
+        var filename = Path.GetFileNameWithoutExtension( path );
+        var extension = Path.GetExtension( path );
+
+        var drawRect = selectionrect;
+        drawRect.x += _labelStyle.CalcSize( new GUIContent( filename ) ).x + 18;
+        drawRect.y++;
+
+        GUI.Label( drawRect, extension );
+    }
+}

--- a/Assets/ThirdParty/ProjectPaneExtensions/ProjectPaneExtensions.cs.meta
+++ b/Assets/ThirdParty/ProjectPaneExtensions/ProjectPaneExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 339decedf35cca648975e4d9194ec69d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
これを導入しました。
[【Unity】Project ビューのファイル名に拡張子を表示するエディタ拡張「ProjectPaneExtensions」紹介 - コガネブログ](https://baba-s.hatenablog.com/entry/2018/11/07/081500)

ベースラインがズレててキモいですが便利なのかなと思います。
![image](https://user-images.githubusercontent.com/1937287/159474498-f981c312-4f82-468f-a902-b64febcf4a3c.png)
